### PR TITLE
Create crud

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,48 @@
 - Repository
     データの永続化やデータソースとのやり取り
 
-Router -> IController <- Controller -> IService <- Service -> IRepository <- Repository -> Data
+Router -> IController <- Controller -> IService <- Service -> IRepsitory <- Repository -> Data
 IController, IService, IRepositoryはインターフェースで実装することで依存関係が小さくなる
+
+## SOLIDの依存関係の逆転の原則で実装する
+
+```go
+// Router
+
+
+// RepositoryImpl -> Data
+type ItemRepository struct {
+	items []models.Item
+}
+
+// Find関数を書くだけでInterfaceを実装したことになる
+func (i *ItemRepository) Find() (*[]models.Item, error){
+    return i.items,nil
+}
+
+// 公開関数
+func NewItemRepository(items []models.Item) IItemRepository {
+    return &ItemRepository{items: items}
+}
+
+// Repository Interface <-  Repository
+type IItemRepository interface {
+	FindAll() (*[]models.Item, error)
+}
+
+// IRepository <- Service で紐づける
+type ItemService struct {
+	repositories repositories.IItemRepository
+}
+
+// Controller -> IItemService <- Service
+type IItemService interface {
+    FindAll() (*[]models.Item, error)
+}
+// Controller...
+
+func (i *ItemService) FindAll() (*[]models.Item, error){
+    return repository.Find() //return (*[]models.Item, error)
+}
+
+```

--- a/main.go
+++ b/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"gin-market/mock/controllers"
+	"gin-market/mock/models"
+	"gin-market/mock/repositories"
+	"gin-market/mock/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	items := []models.Item{
+		{ID: 1, Name: "item1", Price: 100, Description: "desc1", SoldOut: false},
+		{ID: 2, Name: "item2", Price: 200, Description: "desc2", SoldOut: false},
+		{ID: 3, Name: "item3", Price: 300, Description: "desc3", SoldOut: false},
+	}
+
+	itemRepository := repositories.NewItemMemoryRepository(items)
+	ItemService := services.NewItemService(itemRepository)
+	itemController := controllers.NewItemController(ItemService)
+
+	r := gin.Default()
+	r.GET("/items", itemController.FindAll)
+	r.GET("/item/:id", itemController.FindById)
+	// r.GET("/json", func(ctx *gin.Context) {
+	// 	repository.JsonPlaceHolderRepository{}.JsonPlaceHolderDataFindAll()
+	// })
+	// 作成
+	r.POST("/items", itemController.Create)
+	// 更新
+	r.PUT("/items/:id", itemController.Update)
+	//削除
+	r.DELETE("/items/:id", itemController.Delete)
+
+	r.Run("localhost:8080") // listen and serve on 0.0.0.0:8080
+}
+

--- a/mock/controllers/item_controller.go
+++ b/mock/controllers/item_controller.go
@@ -1,0 +1,121 @@
+package controllers
+
+import (
+	"gin-market/mock/dto"
+	"gin-market/mock/services"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+type IItemController interface {
+	// 引数は、Pathに対してハンドリングをするために引数が`*gin.Context`となる
+	FindAll(ctx *gin.Context)
+	FindById(ctx *gin.Context)
+	Create(ctx *gin.Context)
+	Update(ctx *gin.Context)
+	Delete(ctx *gin.Context)
+}
+
+// Controller -> IService
+type ItemController struct {
+	services services.IItemService
+}
+
+// Delete implements IItemController.
+func (i *ItemController) Delete(ctx *gin.Context) {
+	itemId, err := strconv.ParseUint(ctx.Param("id"), 10, 64)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id"})
+		return
+	}
+	err = i.services.Delete(uint(itemId))
+	if err != nil {
+		if err.Error() == "Item not found" {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			return
+		}
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Unexpected Error"})
+		return
+	}
+	ctx.Status(http.StatusOK)
+}
+
+// Update implements IItemController.
+func (i *ItemController) Update(ctx *gin.Context) {
+	itemId, err := strconv.ParseUint(ctx.Param("id"), 10, 64)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id"})
+		return
+	}
+	var input dto.UpdateItemInput
+	if err := ctx.ShouldBindJSON(&input); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	updateItem, err := i.services.Update(uint(itemId), input)
+	if err != nil {
+		if err.Error() == "Item not found" {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			return
+		}
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Unexpected Error"})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"data": updateItem})
+}
+
+// Create implements IItemController.
+func (i *ItemController) Create(ctx *gin.Context) {
+	// validation
+	var input dto.CreateItemInput
+	if err := ctx.ShouldBindJSON(&input); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	//
+	newItem, err := i.services.Create(input)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Unexpected Error"})
+		return
+	}
+	ctx.JSON(http.StatusCreated, gin.H{"data": newItem})
+
+}
+
+// FindById implements IItemController.
+func (i *ItemController) FindById(ctx *gin.Context) {
+	itemId, err := strconv.ParseUint(ctx.Param("id"), 10, 64)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id"})
+		return
+	}
+	item, err := i.services.FindById(uint(itemId))
+	if err != nil {
+		if err.Error() == "Item not found" {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			return
+		}
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Unexpected Error"})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"data": item})
+
+}
+
+// FindAll implements IItemController.
+func (i *ItemController) FindAll(ctx *gin.Context) {
+	items, err := i.services.FindAll()
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Unexpected Error",
+		})
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"data": items})
+}
+
+func NewItemController(service services.IItemService) IItemController {
+	return &ItemController{services: service}
+}

--- a/mock/dto/item_dto.go
+++ b/mock/dto/item_dto.go
@@ -1,0 +1,14 @@
+package dto
+
+type CreateItemInput struct {
+	Name        string `json:"name" binding:"required,min=2"`
+	Price       int    `json:"price" binding:"required"`
+	Description string `json:"description"`
+}
+
+type UpdateItemInput struct {
+	Name        *string `json:"name" binding:"omitnil,min=2"`
+	Price       *uint   `json:"price" binding:"omitnil,min=2"`
+	Description *string `json:"description"`
+	SoldOut     *bool   `json:"soldOut"`
+}

--- a/mock/models/item.go
+++ b/mock/models/item.go
@@ -1,0 +1,9 @@
+package models
+
+type Item struct {
+	ID          uint
+	Name        string
+	Price       uint
+	Description string
+	SoldOut     bool
+}

--- a/mock/repositories/item_repository.go
+++ b/mock/repositories/item_repository.go
@@ -1,0 +1,65 @@
+package repositories
+
+import (
+	"errors"
+	"gin-market/mock/models"
+)
+
+type IItemRepository interface {
+	FindAll() (*[]models.Item, error)
+	FindById(itemId uint) (*models.Item, error)
+	Create(newItem models.Item) (*models.Item, error)
+	Update(updateItem models.Item) (*models.Item, error)
+	Delete(itemId uint) error
+}
+
+type ItemMemoryRepository struct {
+	items []models.Item
+}
+
+// Delete implements IItemRepository.
+func (r *ItemMemoryRepository) Delete(itemId uint) error {
+	for i, v := range r.items {
+		if v.ID == itemId {
+			r.items = append(r.items[:i], r.items[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("item not fount")
+}
+
+// Update implements IItemRepository.
+func (r *ItemMemoryRepository) Update(updateItem models.Item) (*models.Item, error) {
+	for i, v := range r.items {
+		if v.ID == updateItem.ID {
+			r.items[i] = updateItem
+			return &r.items[i], nil
+		}
+	}
+	return nil, errors.New("unexpected error")
+}
+
+// Create implements IItemRepository.
+func (r *ItemMemoryRepository) Create(newItem models.Item) (*models.Item, error) {
+	newItem.ID = uint(len(r.items) + 1)
+	r.items = append(r.items, newItem)
+	return &newItem, errors.New("Itemが作成されませんでした")
+}
+
+// FindById implements IItemRepository.
+func (r *ItemMemoryRepository) FindById(itemId uint) (*models.Item, error) {
+	for _, v := range r.items {
+		if v.ID == itemId {
+			return &v, nil
+		}
+	}
+	return nil, errors.New("Item not found")
+}
+
+func (r *ItemMemoryRepository) FindAll() (*[]models.Item, error) {
+	return &r.items, nil
+}
+
+func NewItemMemoryRepository(items []models.Item) IItemRepository {
+	return &ItemMemoryRepository{items}
+}

--- a/mock/services/item_service.go
+++ b/mock/services/item_service.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"gin-market/mock/dto"
+	"gin-market/mock/models"
+	"gin-market/mock/repositories"
+)
+
+type IItemService interface {
+	FindAll() (*[]models.Item, error)
+	FindById(itemId uint) (*models.Item, error)
+	Create(createItemInput dto.CreateItemInput) (*models.Item, error)
+	Update(itemId uint, updateItemInput dto.UpdateItemInput) (*models.Item, error)
+	Delete(itemId uint) error
+}
+
+// Service -> IRepository
+type ItemService struct {
+	repositories repositories.IItemRepository
+}
+
+// Delete implements IItemService.
+func (s *ItemService) Delete(itemId uint) error {
+	return s.repositories.Delete(itemId)
+}
+
+// Update implements IItemService.
+func (s *ItemService) Update(itemId uint, updateItemInput dto.UpdateItemInput) (*models.Item, error) {
+	targetItem, err := s.repositories.FindById(itemId)
+	if err != nil {
+		return nil, err
+	}
+
+	if updateItemInput.Name != nil {
+		targetItem.Name = *updateItemInput.Name
+	}
+	if updateItemInput.Price != nil {
+		targetItem.Price = *updateItemInput.Price
+	}
+	if updateItemInput.Description != nil {
+		targetItem.Description = *updateItemInput.Description
+	}
+	if updateItemInput.SoldOut != nil {
+		targetItem.SoldOut = *updateItemInput.SoldOut
+	}
+	return s.repositories.Update(*targetItem)
+}
+
+// Create implements IItemService.
+func (s *ItemService) Create(createItemInput dto.CreateItemInput) (*models.Item, error) {
+	newItem := models.Item{
+		Name:        createItemInput.Name,
+		Price:       uint(createItemInput.Price),
+		Description: createItemInput.Description,
+		SoldOut:     false,
+	}
+	return s.repositories.Create(newItem)
+}
+
+// FindById implements IItemService.
+func (s *ItemService) FindById(itemId uint) (*models.Item, error) {
+	return s.repositories.FindById(itemId)
+}
+
+func NewItemService(repository repositories.IItemRepository) IItemService {
+	return &ItemService{repositories: repository}
+}
+
+func (s *ItemService) FindAll() (*[]models.Item, error) {
+	return s.repositories.FindAll()
+}


### PR DESCRIPTION
# 概要
- crudの定義と実装
- interfaceを使ってデータの流れを一方方向になるように実装する 

## 行ったこと
- [アーキテクチャの依存関係の説明を追加](https://github.com/darmadevZone/gin/commit/7a82289aceed84a5939f75fa30a89729735ce0e9)
- [Itemの定義](https://github.com/darmadevZone/gin/commit/ff27900c118724f1ef6a7d4c96fc757445155327)
- [crudの定義と実装](https://github.com/darmadevZone/gin/commit/28d9886f981f71fa6a3e8eacdfe976090274701f)
- [dtoの定義](https://github.com/darmadevZone/gin/commit/7375aff1291fa578fc3052f93b0d195fe6d75153)
- [Itemの定義](https://github.com/darmadevZone/gin/commit/a4cd23a63c38f0d01ca102cb7b5e24a6d5c075d1)

## 影響範囲
- [main.go](https://github.com/darmadevZone/gin/compare/create-crud?expand=1#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261)
- [mock/controllers/item_controller.go](https://github.com/darmadevZone/gin/compare/create-crud?expand=1#diff-221a9bb018c1d458d3dfbbb4c3e8ae6598378161b66b2859b1f0c958c40a496c)
- [mock/dto/item_dto.go](https://github.com/darmadevZone/gin/compare/create-crud?expand=1#diff-4b45a759264abf6891bcd3ba021100f949d185caa447775e586b5d8880b2085e)
- [mock/models/item.go](https://github.com/darmadevZone/gin/compare/create-crud?expand=1#diff-0a1fa6ef140e9befac4333268a154038f8bc9417b9b72140e6290d0c90154ba9)
- [mock/repositories/item_repository.go](https://github.com/darmadevZone/gin/compare/create-crud?expand=1#diff-661f072f6b4d2fafc4c364f8c245b3d019bec0c9ebeacf8092fe7a5c3cab50ab)
- [mock/services/item_service.go](https://github.com/darmadevZone/gin/compare/create-crud?expand=1#diff-687cf184335574ac81281571d4fab2eb40a7694b750f517514d583e2a9d3cf21)
- [README.md](https://github.com/darmadevZone/gin/compare/create-crud?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)

## チェックリスト


## 反省点
コミット粒度を小さくする

## 補足

